### PR TITLE
Aricoder optimizations, further Bitops optimization

### DIFF
--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -308,8 +308,7 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	std::fill(null_table->links, null_table->links + max_context, start_table);
 	
 	// alloc memory for storage & contexts
-	contexts = new table_s*[max_order + 3];
-	std::fill(contexts, contexts + max_order + 3, nullptr);
+	contexts = std::vector<table_s*>(max_order + 3);
 	
 	// integrate tables into contexts
 	contexts[ 0 ] = null_table;
@@ -356,7 +355,6 @@ model_s::~model_s()
 	delete context;
 	
 	// free everything else
-	delete[] contexts;
 	delete[] scoreboard;
 }
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -273,9 +273,6 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim ) :
 	table_s* start_table = new table_s;
 	start_table->links = std::vector<table_s*>(max_context);
 	
-	// build links for null table
-	null_table->links = std::vector<table_s*>(max_context, start_table);
-	
 	// integrate tables into contexts
 	contexts[ 0 ] = null_table;
 	contexts[ 1 ] = start_table;
@@ -303,7 +300,6 @@ model_s::~model_s()
 	delete contexts[1];
 	
 	// clean up null table
-	contexts[0]->links.clear(); // Don't delete the already-deleted links again!
 	delete contexts[0];
 	
 	// free everything else
@@ -600,9 +596,6 @@ model_b::model_b( int max_c, int max_o, int c_lim ) :
 	// set up start table
 	table* start_table = new table;
 	start_table->links = std::vector<table*>(max_context);
-	
-	// build links for start table
-	null_table->links = std::vector<table*>(max_context, start_table);
 		
 	// integrate tables into contexts
 	contexts[ 0 ] = null_table;
@@ -631,7 +624,6 @@ model_b::~model_b()
 	delete contexts[1];
 	
 	// clean up null table
-	contexts[0]->links.clear(); // Don't delete the already-deleted links again!
 	delete contexts[0];
 }
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -491,7 +491,11 @@ int model_s::convert_symbol_to_int(uint32_t count, symbol *s)
 
 	// go through the totals table, search the symbol that matches the count
 	int c;
-	for (c = 1; count < totals[c]; c++);	
+	for (c = 1; c < totals.size(); c++) {
+		if (count >= totals[c]) {
+			break;
+		}
+	}
 	// set up the current symbol
 	s->low_count = totals[c]; // It is guaranteed that there exists such a symbol.
 	s->high_count = totals[c - 1]; // This is guaranteed to not go out of bounds since the search started at index 1 of totals.

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -495,7 +495,7 @@ void model_s::get_symbol_scale( symbol *s )
 	converts a count to an int, called after get_symbol_scale
 	----------------------------------------------- */
 	
-int model_s::convert_symbol_to_int(int count, symbol *s)
+int model_s::convert_symbol_to_int(uint32_t count, symbol *s)
 {
 	// seek the symbol that matches the count,
 	// also, set low- and high count for the symbol - it has to be removed from the stream
@@ -503,7 +503,7 @@ int model_s::convert_symbol_to_int(int count, symbol *s)
 
 	// go through the totals table, search the symbol that matches the count
 	int c;
-	for (c = 1; count < (signed) totals[c]; c++);	
+	for (c = 1; count < totals[c]; c++);	
 	// set up the current symbol
 	s->low_count = totals[c]; // It is guaranteed that there exists such a symbol.
 	s->high_count = totals[c - 1]; // This is guaranteed to not go out of bounds since the search started at index 1 of totals.
@@ -824,10 +824,10 @@ void model_b::get_symbol_scale( symbol *s )
 	converts a count to an int, called after get_symbol_scale
 	----------------------------------------------- */
 	
-int model_b::convert_symbol_to_int( int count, symbol *s )
+int model_b::convert_symbol_to_int(uint32_t count, symbol *s)
 {
 	table* context = contexts[ max_order ];
-	unsigned short counts0 = context->counts[ 0 ];
+	auto counts0 = context->counts[ 0 ];
 	
 	// set up the current symbol
 	if ( count < counts0 ) {

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -1,11 +1,10 @@
-#include <stdlib.h>
-#include "bitops.h"
 #include "aricoder.h"
+
+#include "bitops.h"
+
 #include <algorithm>
 #include <functional>
-
-#define ERROR_EXIT { error = true; exit( 0 ); }
-
+#include <stdlib.h>
 
 /* -----------------------------------------------
 	constructor for aricoder class
@@ -272,10 +271,6 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	table_s* null_table;
 	table_s* start_table;
 	int i;
-	
-	
-	// set error false
-	error = false;	
 	
 	// copy settings into model
 	max_symbol  = max_s;
@@ -753,9 +748,6 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	table* start_table;
 	int i;
 	
-	
-	// set error false
-	error = false;	
 	
 	// copy settings into model
 	max_context = max_c;

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -328,7 +328,7 @@ void model_s::update_model( int symbol )
 			// if count for that symbol have gone above the maximum count
 			// the table has to be resized (scale factor 2)
 			if (count == max_count) {
-				context->rescale_table(1);
+				context->rescale_table();
 			}
 		}
 	}
@@ -378,9 +378,9 @@ void model_s::shift_context( int c )
 	flushes the whole model by dividing through a specific scale factor
 	----------------------------------------------- */
 	
-void model_s::flush_model( int scale_factor )
+void model_s::flush_model()
 {
-	contexts[1]->recursive_flush(scale_factor);
+	contexts[1]->recursive_flush();
 }
 
 
@@ -649,7 +649,7 @@ void model_b::update_model( int symbol )
 		// if counts for that symbol have gone above the maximum count
 		// the table has to be resized (scale factor 2)
 		if ( context->counts[ symbol ] >= max_count )
-			context->rescale_table(1);
+			context->rescale_table();
 	}
 }
 
@@ -692,9 +692,9 @@ void model_b::shift_context( int c )
 	flushes the whole model by dividing through a specific scale factor
 	----------------------------------------------- */
 	
-void model_b::flush_model( int scale_factor )
+void model_b::flush_model()
 {
-	contexts[1]->recursive_flush(scale_factor);
+	contexts[1]->recursive_flush();
 }
 
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -450,13 +450,11 @@ int model_s::convert_int_to_symbol( int c, symbol *s )
 	s->scale = totals[ 0 ];
 	
 	// check if that symbol exists in the current table. send escape otherwise
-	if ( c >= 0 ) {
-		if ( context->counts[ c ] > 0 ) {
-			// return high and low count for the current symbol
-			s->low_count  = totals[ c + 2 ];
-			s->high_count = totals[ c + 1 ];
-			return 0;
-		}
+	if ( context->counts[ c ] > 0 ) {
+		// return high and low count for the current symbol
+		s->low_count  = totals[ c + 2 ];
+		s->high_count = totals[ c + 1 ];
+		return 0;
 	}
 	
 	// return high and low count for the escape symbol
@@ -514,7 +512,7 @@ int model_s::convert_symbol_to_int(uint32_t count, symbol *s)
 	totals are calculated by accumulating counts in the current table_s
 	----------------------------------------------- */
 
-void model_s::totalize_table( table_s *context )
+void model_s::totalize_table( table_s* context )
 {
 	// update exclusion is used, so this has to be done each time
 	// escape probability calculation also takes place here

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -254,9 +254,9 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	
 	// set up null table
 	null_table = ( table_s* ) calloc( 1, sizeof( table_s ) );
-	if ( null_table == NULL ) ERROR_EXIT;	
+	if ( null_table == nullptr ) ERROR_EXIT;	
 	null_table->counts = ( unsigned short* ) calloc( max_symbol, sizeof( short ) );
-	if ( null_table->counts == NULL ) ERROR_EXIT;
+	if ( null_table->counts == nullptr ) ERROR_EXIT;
 	for ( i = 0; i < max_symbol; i++ )
 		null_table->counts[ i ] = 1; // set all probabilities
 	// set up internal counts
@@ -265,9 +265,9 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	
 	// set up start table
 	start_table = ( table_s* ) calloc( 1, sizeof( table_s ) );
-    if ( start_table == NULL ) ERROR_EXIT;	
+    if ( start_table == nullptr ) ERROR_EXIT;	
 	start_table->links = ( table_s** ) calloc( max_context, sizeof( table_s* ) );
-	if ( start_table->links == NULL ) ERROR_EXIT;
+	if ( start_table->links == nullptr ) ERROR_EXIT;
 	// set up internal counts
 	start_table->max_count = 0;
 	start_table->max_symbol = 0;
@@ -275,13 +275,13 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	// build links for start table & null table
 	start_table->lesser = null_table;
 	null_table->links = ( table_s** ) calloc( max_context, sizeof( table_s* ) );
-	if ( null_table->links == NULL ) ERROR_EXIT;
+	if ( null_table->links == nullptr ) ERROR_EXIT;
 	for ( i = 0; i < max_context; i++ )
 		null_table->links[ i ] = start_table;
 	
 	// alloc memory for storage & contexts
 	storage = ( table_s** ) calloc( max_order + 3, sizeof( table_s* ) );
-	if ( storage == NULL ) ERROR_EXIT;
+	if ( storage == nullptr ) ERROR_EXIT;
 	contexts = storage + 1;
 	
 	// integrate tables into contexts
@@ -292,17 +292,17 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	for ( i = 1; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[ i ] = ( table_s* ) calloc( 1, sizeof( table_s ) );
-	    if ( contexts[ i ] == NULL ) ERROR_EXIT;
+	    if ( contexts[ i ] == nullptr ) ERROR_EXIT;
 		contexts[ i ]->max_count  = 0;
 		contexts[ i ]->max_symbol = 0;
 		// build forward and backward links
 		contexts[ i ]->lesser = contexts[ i - 1 ];
 		if ( i < max_order ) {
 			contexts[ i ]->links = ( table_s** ) calloc( max_context, sizeof( table_s* ) );
-			if ( contexts[ i ]->links == NULL ) ERROR_EXIT;
+			if ( contexts[ i ]->links == nullptr ) ERROR_EXIT;
 		}
 		else {
-			contexts[ i ]->links = NULL;
+			contexts[ i ]->links = nullptr;
 		}
 		contexts[ i - 1 ]->links[ 0 ] = contexts[ i ];
 	}
@@ -324,9 +324,9 @@ model_s::~model_s( void )
 	
 	// clean up null table
 	context = contexts[ -1 ];	
-	if ( context->links  != NULL )
+	if ( context->links  != nullptr )
 		free( context->links  );
-	if ( context->counts != NULL ) free( context->counts );
+	if ( context->counts != nullptr ) free( context->counts );
 	free ( context );
 	
 	// free everything else
@@ -371,8 +371,7 @@ void model_s::update_model( int symbol )
 	
 	// reset scoreboard and current order
 	current_order = max_order;
-	for ( i = 0; i < max_symbol; i++ )
-		scoreboard[ i ] = 0;
+	std::fill(scoreboard, scoreboard + max_symbol, char(0));
 	sb0_count = max_symbol;
 }
 
@@ -396,12 +395,12 @@ void model_s::shift_context( int c )
 		context = contexts[ i - 1 ]->links[ c ];
 		
 		// check if context exists, build if needed
-		if ( context == NULL ) {
+		if ( context == nullptr ) {
 			// reserve memory for next table_s
 			context = ( table_s* ) calloc( 1, sizeof( table_s ) );
-			if ( context == NULL ) ERROR_EXIT;			
-			// set counts NULL
-			context->counts = NULL;
+			if ( context == nullptr ) ERROR_EXIT;			
+			// set counts nullptr
+			context->counts = nullptr;
 			// setup internal counts
 			context->max_count  = 0;
 			context->max_symbol = 0;
@@ -409,11 +408,11 @@ void model_s::shift_context( int c )
 			context->lesser = contexts[ i - 2 ]->links[ c ];
 			// finished here if this is a max order context
 			if ( i == max_order )
-				context->links = NULL;
+				context->links = nullptr;
 			else {
 				// build links to higher order tables otherwise
 				context->links = ( table_s** ) calloc( max_context, sizeof( table_s* ) );
-				if ( context->links == NULL ) ERROR_EXIT;
+				if ( context->links == nullptr ) ERROR_EXIT;
 				// add lesser link for higher context (see above)
 				contexts[ i + 1 ]->lesser = context;
 			}
@@ -585,7 +584,7 @@ void model_s::totalize_table( table_s *context )
 	counts = context->counts;
 	
 	// check counts
-	if ( counts != NULL ) {	// if counts are already set
+	if ( counts != nullptr ) {	// if counts are already set
 		// locally store current fill/symbol count
 		local_symb = sb0_count;
 		
@@ -628,7 +627,7 @@ void model_s::totalize_table( table_s *context )
 	else { // if counts are not already set
 		// setup counts for current table
 		context->counts = ( unsigned short* ) calloc( max_symbol, sizeof( short ) );
-		if ( context->counts == NULL ) ERROR_EXIT;
+		if ( context->counts == nullptr ) ERROR_EXIT;
 		// set totals table -> only escape probability included
 		totals[ 0 ] = 1;
 		totals[ 1 ] = 0;
@@ -647,7 +646,7 @@ inline void model_s::rescale_table( table_s* context, int scale_factor )
 	int i;
 	
 	// return now if counts not set
-	if ( counts == NULL ) return;
+	if ( counts == nullptr ) return;
 	
 	// now scale the table by bitshifting each count
 	for ( i = 0; i < lst_symbol; i++ ) {
@@ -673,10 +672,10 @@ inline void model_s::recursive_flush( table_s* context, int scale_factor )
 {
 	int i;
 
-	// go through each link != NULL
-	if ( context->links != NULL )
+	// go through each link != nullptr
+	if ( context->links != nullptr )
 		for ( i = 0; i < max_context; i++ )
-			if ( context->links[ i ] != NULL )
+			if ( context->links[ i ] != nullptr )
 				recursive_flush( context->links[ i ], scale_factor );
     
 	// rescale specific table
@@ -694,16 +693,16 @@ inline void model_s::recursive_cleanup( table_s *context )
 	
 	int i;
 
-	// go through each link != NULL
-	if ( context->links != NULL ) {
+	// go through each link != nullptr
+	if ( context->links != nullptr ) {
 		for ( i = 0; i < max_context; i++ )
-			if ( context->links[ i ] != NULL )
+			if ( context->links[ i ] != nullptr )
 				recursive_cleanup( context->links[ i ] );
 		free ( context->links );
 	}
 	
 	// clean up table	
-	if ( context->counts != NULL ) free ( context->counts );	
+	if ( context->counts != nullptr ) free ( context->counts );	
 	free( context );
 }
 
@@ -735,31 +734,31 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	
 	// set up null table
 	null_table = ( table* ) calloc( 1, sizeof( table ) );
-	if ( null_table == NULL ) ERROR_EXIT;
+	if ( null_table == nullptr ) ERROR_EXIT;
 	
 	null_table->counts = ( unsigned short* ) calloc( 2, sizeof( short ) );
-	if ( null_table->counts == NULL ) ERROR_EXIT;
+	if ( null_table->counts == nullptr ) ERROR_EXIT;
 	null_table->counts[ 0 ] = 1;
 	null_table->counts[ 1 ] = 1;
 	null_table->scale = 2;
 	
 	// set up start table
 	start_table = ( table* ) calloc( 1, sizeof( table ) );
-    if ( start_table == NULL ) ERROR_EXIT;	
+    if ( start_table == nullptr ) ERROR_EXIT;	
 	start_table->links = ( table** ) calloc( max_context, sizeof( table* ) );
-	if ( start_table->links == NULL ) ERROR_EXIT;
+	if ( start_table->links == nullptr ) ERROR_EXIT;
 	start_table->scale = 0;
 	
 	// build links for start table & null table
 	start_table->lesser = null_table;
 	null_table->links = ( table** ) calloc( max_context, sizeof( table* ) );
-	if ( null_table->links == NULL ) ERROR_EXIT;
+	if ( null_table->links == nullptr ) ERROR_EXIT;
 	for ( i = 0; i < max_context; i++ )
 		null_table->links[ i ] = start_table;
 	
 	// alloc memory for storage & contexts
 	storage = ( table** ) calloc( max_order + 3, sizeof( table* ) );
-	if ( storage == NULL ) ERROR_EXIT;
+	if ( storage == nullptr ) ERROR_EXIT;
 	contexts = storage + 1;
 	
 	// integrate tables into contexts
@@ -770,16 +769,16 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	for ( i = 1; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[ i ] = ( table* ) calloc( 1, sizeof( table ) );
-	    if ( contexts[ i ] == NULL ) ERROR_EXIT;
+	    if ( contexts[ i ] == nullptr ) ERROR_EXIT;
 		contexts[ i ]->scale = 0;
 		// build forward and backward links
 		contexts[ i ]->lesser = contexts[ i - 1 ];
 		if ( i < max_order ) {
 			contexts[ i ]->links = ( table** ) calloc( max_context, sizeof( table* ) );
-			if ( contexts[ i ]->links == NULL ) ERROR_EXIT;
+			if ( contexts[ i ]->links == nullptr ) ERROR_EXIT;
 		}
 		else {
-			contexts[ i ]->links = NULL;
+			contexts[ i ]->links = nullptr;
 		}
 		contexts[ i - 1 ]->links[ 0 ] = contexts[ i ];
 	}
@@ -801,9 +800,9 @@ model_b::~model_b( void )
 	
 	// clean up null table
 	context = contexts[ -1 ];	
-	if ( context->links  != NULL )
+	if ( context->links  != nullptr )
 		free( context->links  );
-	if ( context->counts != NULL ) free( context->counts );
+	if ( context->counts != nullptr ) free( context->counts );
 	free ( context );
 	
 	// free everything else
@@ -854,23 +853,23 @@ void model_b::shift_context( int c )
 		context = contexts[ i - 1 ]->links[ c ];
 		
 		// check if context exists, build if needed
-		if ( context == NULL ) {
+		if ( context == nullptr ) {
 			// reserve memory for next table
 			context = ( table* ) calloc( 1, sizeof( table ) );
-			if ( context == NULL ) ERROR_EXIT;			
-			// set internal counts NULL
-			context->counts = NULL;
+			if ( context == nullptr ) ERROR_EXIT;			
+			// set internal counts nullptr
+			context->counts = nullptr;
 			context->scale  = 0;	
 			// link lesser context later if not existing, this is done below
 			context->lesser = contexts[ i - 2 ]->links[ c ];
 			// finished here if this is a max order context
 			if ( i == max_order ) {
-				context->links = NULL;
+				context->links = nullptr;
 			}
 			else {
 				// build links to higher order tables otherwise
 				context->links = ( table** ) calloc( max_context, sizeof( table* ) );
-				if ( context->links == NULL ) ERROR_EXIT;
+				if ( context->links == nullptr ) ERROR_EXIT;
 				// add lesser link for higher context (see above)
 				contexts[ i + 1 ]->lesser = context;
 			}
@@ -970,10 +969,10 @@ inline void model_b::check_counts( table *context )
 	unsigned short* counts = context->counts;
 	
 	// check if counts are available
-	if ( counts == NULL ) {
+	if ( counts == nullptr ) {
 		// setup counts for current table
 		counts = ( unsigned short* ) calloc( 2, sizeof( short ) );
-		if ( counts == NULL ) ERROR_EXIT;
+		if ( counts == nullptr ) ERROR_EXIT;
 		counts[ 0 ] = 1;
 		counts[ 1 ] = 1;
 		// set scale
@@ -992,7 +991,7 @@ inline void model_b::rescale_table( table* context, int scale_factor )
 	unsigned short* counts = context->counts;
 	
 	// return now if counts not set
-	if ( counts == NULL ) return;
+	if ( counts == nullptr ) return;
 	
 	// now scale the table by bitshifting each count, be careful not to set any count zero
 	counts[ 0 ] >>= scale_factor;
@@ -1011,10 +1010,10 @@ inline void model_b::recursive_flush( table* context, int scale_factor )
 {
 	int i;
 
-	// go through each link != NULL
-	if ( context->links != NULL )
+	// go through each link != nullptr
+	if ( context->links != nullptr )
 		for ( i = 0; i < max_context; i++ )
-			if ( context->links[ i ] != NULL )
+			if ( context->links[ i ] != nullptr )
 				recursive_flush( context->links[ i ], scale_factor );
     
 	// rescale specific table
@@ -1030,15 +1029,15 @@ inline void model_b::recursive_cleanup( table *context )
 {
 	int i;
 
-	// go through each link != NULL
-	if ( context->links != NULL ) {
+	// go through each link != nullptr
+	if ( context->links != nullptr ) {
 		for ( i = 0; i < max_context; i++ )
-			if ( context->links[ i ] != NULL )
+			if ( context->links[ i ] != nullptr )
 				recursive_cleanup( context->links[ i ] );
 		free ( context->links );
 	}
 	
 	// clean up table	
-	if ( context->counts != NULL ) free ( context->counts );	
+	if ( context->counts != nullptr ) free ( context->counts );	
 	free( context );
 }

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -103,13 +103,13 @@ void aricoder::writeNrbitsAsZero() {
 		int remainingBits = 8 - cbit;
 		nrbits -= remainingBits;
 		bbyte <<= remainingBits;
-		sptr->write(&bbyte, 1, 1);
+		sptr->write_byte(bbyte);
 		cbit = 0;
 	}
 
 	constexpr uint8_t zero = 0;
 	while (nrbits >= 8) {
-		sptr->write((void*)&zero, 1, 1);
+		sptr->write_byte(zero);
 		nrbits -= 8;
 	}
 	/*
@@ -127,13 +127,13 @@ void aricoder::writeNrbitsAsOne() {
 		nrbits -= remainingBits;
 		bbyte <<= remainingBits;
 		bbyte |= std::numeric_limits<uint8_t>::max() >> (8 - remainingBits);
-		sptr->write(&bbyte, 1, 1);
+		sptr->write_byte(bbyte);
 		cbit = 0;
 	}
 
 	constexpr uint8_t all_ones = std::numeric_limits<uint8_t>::max();
 	while (nrbits >= 8) {
-		sptr->write((void*)&all_ones, 1, 1);
+		sptr->write_byte(all_ones);
 		nrbits -= 8;
 	}
 
@@ -220,7 +220,7 @@ unsigned char aricoder::read_bit()
 {
 	// read in new byte if needed
 	if ( cbit == 0 ) {
-		if ( !sptr->read_byte( &bbyte)) // read next byte if available
+		if ( !sptr->read_byte(&bbyte)) // read next byte if available
 			bbyte = 0; // if no more data is left in the stream
 		cbit = 8;
 	}

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -296,9 +296,6 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	// set up start table
 	table_s* start_table = new table_s;
 	start_table->links = std::vector<table_s*>(max_context);
-	// set up internal counts
-	start_table->max_count = 0;
-	start_table->max_symbol = 0;
 	
 	// build links for null table
 	null_table->links = std::vector<table_s*>(max_context, start_table);
@@ -313,8 +310,6 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	for (int i = 2; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table_s;
-		contexts[ i ]->max_count  = 0;
-		contexts[ i ]->max_symbol = 0;
 		// build forward links
 		if ( i < max_order ) {
 			contexts[i]->links = std::vector<table_s*>(max_context);
@@ -399,10 +394,7 @@ void model_s::shift_context( int c )
 		// check if context exists, build if needed
 		if ( context == nullptr ) {
 			// reserve memory for next table_s
-			context = new table_s;		
-			// setup internal counts
-			context->max_count  = 0;
-			context->max_symbol = 0;
+			context = new table_s;
 			// finished here if this is a max order context
 			if ( i < max_order ) {
 				// build links to higher order tables otherwise
@@ -707,7 +699,6 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	// set up start table
 	table* start_table = new table;
 	start_table->links = std::vector<table*>(max_context);
-	start_table->scale = 0;
 	
 	// build links for start table & null table
 	null_table->links = std::vector<table*>(max_context, start_table);
@@ -722,7 +713,6 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	for (int i = 2; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table;
-		contexts[ i ]->scale = 0;
 		// build forward links
 		if ( i < max_order ) {
 			contexts[i]->links = std::vector<table*>(max_context);
@@ -794,7 +784,6 @@ void model_b::shift_context( int c )
 		if ( context == nullptr ) {
 			// reserve memory for next table
 			context = new table;		
-			context->scale  = 0;
 			// finished here if this is a max order context
 			if ( i < max_order) {
 				// build links to higher order tables otherwise

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -349,13 +349,11 @@ model_s::~model_s()
 
 
 /* -----------------------------------------------
-	updates statistics for a specific symbol / resets to highest order
+	Updates statistics for a specific symbol / resets to highest order.
+	Use -1 if you just want to reset without updating statistics.
 	----------------------------------------------- */
-
 void model_s::update_model( int symbol )
-{
-	// use -1 if you just want to reset without updating statistics
-		
+{		
 	// only contexts, that were actually used to encode
 	// the symbol get its count updated
 	if ( symbol >= 0 ) {
@@ -366,12 +364,13 @@ void model_s::update_model( int symbol )
 			// update count for specific symbol & scale
 			count++;
 			// store side information for totalize_table
-			if ( count > context->max_count ) context->max_count = count;
-			if ( symbol >= context->max_symbol ) context->max_symbol = symbol+1;
+			context->max_count = std::max(count, context->max_count);
+			context->max_symbol = std::max(uint16_t(symbol + 1), context->max_symbol);
 			// if count for that symbol have gone above the maximum count
 			// the table has to be resized (scale factor 2)
-			if ( count >= max_count )
-				rescale_table( context, 1 );
+			if (count == max_count) {
+				rescale_table(context, 1);
+			}
 		}
 	}
 	

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -375,7 +375,7 @@ void model_s::shift_context( int c )
 
 
 /* -----------------------------------------------
-	flushes the whole model by dividing through a specific scale factor
+	Flushes the entire model by calling rescale_table on all contexts.
 	----------------------------------------------- */
 	
 void model_s::flush_model()
@@ -385,50 +385,18 @@ void model_s::flush_model()
 
 
 /* -----------------------------------------------
-	exclude specific symbols using this function
+	Excludes every symbol above c.
 	----------------------------------------------- */
 	
-void model_s::exclude_symbols( char rule, int c )
+void model_s::exclude_symbols(int c)
 {
 	// exclusions are back to normal after update_model is used	
-	// modify scoreboard according to rule and value
-	switch ( rule )
-	{
-		case 'a':
-			// above rule
-			// every symbol above c is excluded
-			for ( c = c + 1; c < max_symbol; c++ ) {
-				if ( !scoreboard[ c ] ) {
-					scoreboard[ c ] = true;
-					sb0_count--;
-				}
-			}
-			break;
-		
-		case 'b':
-			// below rule
-			// every symbol below c is excluded
-			for ( c = c - 1; c >= 0; c-- ) {
-				if ( !scoreboard[ c ] ) {
-					scoreboard[ c ] = true;
-					sb0_count--;
-				}
-			}
-			break;
-		
-		case 'e':
-			// equal rule
-			// only c is excluded
-			if ( !scoreboard[ c ] ) {
-				scoreboard[ c ] = true;
-				sb0_count--;
-			}
-			break;
-		
-		default:
-			// unknown rule
-			// do nothing
-			break;
+
+	for ( c = c + 1; c < max_symbol; c++ ) {
+		if ( !scoreboard[ c ] ) {
+			scoreboard[ c ] = true;
+			sb0_count--;
+		}
 	}
 }
 
@@ -689,7 +657,7 @@ void model_b::shift_context( int c )
 
 
 /* -----------------------------------------------
-	flushes the whole model by dividing through a specific scale factor
+	Flushes the entire model by calling rescale_table on all contexts.
 	----------------------------------------------- */
 	
 void model_b::flush_model()

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -206,8 +206,7 @@ void aricoder::decode( symbol* s )
 		chigh_local++;
 		ccode_local <<= 1;
 		ccode_local |= read_bit();
-	}
-
+	}	
 	chigh = chigh_local;
 	clow = clow_local;
 	ccode = ccode_local;
@@ -221,7 +220,7 @@ unsigned char aricoder::read_bit()
 {
 	// read in new byte if needed
 	if ( cbit == 0 ) {
-		if ( sptr->read( &bbyte, 1, 1 ) == 0 ) // read next byte if available
+		if ( !sptr->read_byte( &bbyte)) // read next byte if available
 			bbyte = 0; // if no more data is left in the stream
 		cbit = 8;
 	}

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -235,34 +235,32 @@ unsigned char aricoder::read_bit()
 
 /* -----------------------------------------------
 	universal statistical model for arithmetic coding
+	
+	boundaries of this model:
+	max_s (maximum symbol) -> 1 <= max_s <= 1024 (???)
+	max_c (maximum context) -> 1 <= max_c <= 1024 (???)
+	max_o (maximum order) -> -1 <= max_o <= 4
+	c_lim (maximum count) -> 2 <= c_lim <= 4096 (???)
+	WARNING: this can be memory intensive, so don't overdo it
+	max_s == 256; max_c == 256; max_o == 4 would be way too much
 	----------------------------------------------- */
 	
-model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
+model_s::model_s( int max_s, int max_c, int max_o, int c_lim ) :
+		// Copy settings into the model:
+		max_symbol(max_s),
+		max_context(max_c),
+		max_order(max_o + 1),
+		max_count(c_lim),
+
+		sb0_count(max_s),
+		current_order(max_o + 1)
 {
-	// boundaries of this model:
-	// max_s (maximum symbol) -> 1 <= max_s <= 1024 (???)
-	// max_c (maximum context) -> 1 <= max_c <= 1024 (???)
-	// max_o (maximum order) -> -1 <= max_o <= 4
-	// c_lim (maximum count) -> 2 <= c_lim <= 4096 (???)
-	// WARNING: this can be memory intensive, so don't overdo it
-	// max_s == 256; max_c == 256; max_o == 4 would be way too much
-	
-	// copy settings into model
-	max_symbol  = max_s;
-	max_context = max_c;
-	max_order   = max_o + 1;
-	max_count   = c_lim;
-	
 	// alloc memory for totals table
 	totals = std::vector<uint32_t>(max_symbol + 2);
 	
 	// alloc memory for scoreboard, set sb0_count
 	scoreboard = new bool[max_symbol];
 	std::fill(scoreboard, scoreboard + max_symbol, false);
-	sb0_count = max_symbol;
-	
-	// set current order
-	current_order = max_order;
 	
 	// set up null table
 	table_s* null_table = new table_s;
@@ -652,20 +650,19 @@ inline void model_s::recursive_cleanup( table_s *context )
 
 /* -----------------------------------------------
 	special version of model_s for binary coding
+	
+	boundaries of this model:
+	... (maximum symbol) -> 2 (0 or 1 )
+	max_c (maximum context) -> 1 <= max_c <= 1024 (???)
+	max_o (maximum order) -> -1 <= max_o <= 4
 	----------------------------------------------- */
 
-model_b::model_b( int max_c, int max_o, int c_lim )
+model_b::model_b( int max_c, int max_o, int c_lim ) :
+		// Copy settings into the model:
+		max_context(max_c),
+		max_order(max_o + 1),
+		max_count(c_lim)
 {
-	// boundaries of this model:
-	// ... (maximum symbol) -> 2 (0 or 1 )
-	// max_c (maximum context) -> 1 <= max_c <= 1024 (???)
-	// max_o (maximum order) -> -1 <= max_o <= 4
-	
-	// copy settings into model
-	max_context = max_c;
-	max_order   = max_o + 1;
-	max_count   = c_lim;
-	
 	// set up null table
 	table* null_table = new table;
 	null_table->counts = std::vector<uint16_t>(2, uint16_t(1));

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -304,7 +304,6 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	start_table->lesser = null_table;
 	null_table->links = std::vector<table_s*>(max_context, start_table);
 	
-	// alloc memory for storage & contexts
 	contexts = std::vector<table_s*>(max_order + 3);
 	
 	// integrate tables into contexts
@@ -411,7 +410,7 @@ void model_s::shift_context( int c )
 			// finished here if this is a max order context
 			if ( i < max_order ) {
 				// build links to higher order tables otherwise
-				context->links = std::vector<table_s*>(max_context);
+				context->links.resize(max_context);
 				// add lesser link for higher context (see above)
 				contexts[ i + 1 ]->lesser = context;
 			}
@@ -618,7 +617,7 @@ void model_s::totalize_table( table_s *context )
 		totals[ 0 ] = totals[ 1 ] + esc_prob;
 	} else { // if counts are not already set
 		// setup counts for current table
-		context->counts = std::vector<uint16_t>(max_symbol);
+		context->counts.resize(max_symbol);
 		// set totals table -> only escape probability included
 		totals[ 0 ] = 1;
 		totals[ 1 ] = 0;
@@ -720,7 +719,6 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	start_table->lesser = null_table;
 	null_table->links = std::vector<table*>(max_context, start_table);
 	
-	// alloc memory for storage & contexts
 	contexts = std::vector<table*>(max_order + 2);
 	
 	// integrate tables into contexts
@@ -810,7 +808,7 @@ void model_b::shift_context( int c )
 			// finished here if this is a max order context
 			if ( i < max_order) {
 				// build links to higher order tables otherwise
-				context->links = std::vector<table*>(max_context);
+				context->links.resize(max_context);
 				// add lesser link for higher context (see above)
 				contexts[ i + 1 ]->lesser = context;
 			}

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -728,7 +728,7 @@ model_b::~model_b()
 	recursive_cleanup(contexts[1]);
 	
 	// clean up null table
-	delete[] contexts[0];
+	delete contexts[0];
 }
 
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -324,16 +324,12 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	----------------------------------------------- */
 
 model_s::~model_s()
-{
-	table_s* context;
-	
+{	
 	// clean up each 'normal' table
-	context = contexts[1];
-	recursive_cleanup ( context );
+	recursive_cleanup(contexts[1]);
 	
 	// clean up null table
-	context = contexts[0];
-	delete context;
+	delete contexts[0];
 	
 	// free everything else
 	delete[] scoreboard;
@@ -728,16 +724,11 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	
 model_b::~model_b()
 {
-	table* context;
-	
-	
 	// clean up each 'normal' table
-	context = contexts[ 1 ];
-	recursive_cleanup ( context );
+	recursive_cleanup(contexts[1]);
 	
 	// clean up null table
-	context = contexts[ 0];
-	delete context;
+	delete[] contexts[0];
 }
 
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -300,8 +300,7 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	start_table->max_count = 0;
 	start_table->max_symbol = 0;
 	
-	// build links for start table & null table
-	start_table->lesser = null_table;
+	// build links for null table
 	null_table->links = std::vector<table_s*>(max_context, start_table);
 	
 	contexts = std::vector<table_s*>(max_order + 3);
@@ -316,8 +315,7 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 		contexts[i] = new table_s;
 		contexts[ i ]->max_count  = 0;
 		contexts[ i ]->max_symbol = 0;
-		// build forward and backward links
-		contexts[ i ]->lesser = contexts[ i - 1 ];
+		// build forward links
 		if ( i < max_order ) {
 			contexts[i]->links = std::vector<table_s*>(max_context);
 		}
@@ -405,14 +403,10 @@ void model_s::shift_context( int c )
 			// setup internal counts
 			context->max_count  = 0;
 			context->max_symbol = 0;
-			// link lesser context later if not existing, this is done below
-			context->lesser = contexts[ i - 2 ]->links[ c ];
 			// finished here if this is a max order context
 			if ( i < max_order ) {
 				// build links to higher order tables otherwise
 				context->links.resize(max_context);
-				// add lesser link for higher context (see above)
-				contexts[ i + 1 ]->lesser = context;
 			}
 			// put context to its right place
 			contexts[ i - 1 ]->links[ c ] = context;
@@ -716,7 +710,6 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	start_table->scale = 0;
 	
 	// build links for start table & null table
-	start_table->lesser = null_table;
 	null_table->links = std::vector<table*>(max_context, start_table);
 	
 	contexts = std::vector<table*>(max_order + 2);
@@ -730,8 +723,7 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 		// set up current order table
 		contexts[i] = new table;
 		contexts[ i ]->scale = 0;
-		// build forward and backward links
-		contexts[ i ]->lesser = contexts[ i - 1 ];
+		// build forward links
 		if ( i < max_order ) {
 			contexts[i]->links = std::vector<table*>(max_context);
 		}
@@ -802,15 +794,11 @@ void model_b::shift_context( int c )
 		if ( context == nullptr ) {
 			// reserve memory for next table
 			context = new table;		
-			context->scale  = 0;	
-			// link lesser context later if not existing, this is done below
-			context->lesser = contexts[ i - 2 ]->links[ c ];
+			context->scale  = 0;
 			// finished here if this is a max order context
 			if ( i < max_order) {
 				// build links to higher order tables otherwise
 				context->links.resize(max_context);
-				// add lesser link for higher context (see above)
-				contexts[ i + 1 ]->lesser = context;
 			}
 			// put context to its right place
 			contexts[ i - 1 ]->links[ c ] = context;

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -661,7 +661,6 @@ inline void model_s::rescale_table( table_s* context, int scale_factor )
 	
 inline void model_s::recursive_flush( table_s* context, int scale_factor )
 {
-	// go through each link != nullptr
 	for (auto& link : context->links) {
 		if (link != nullptr) {
 			recursive_flush(link, scale_factor);
@@ -943,7 +942,6 @@ inline void model_b::rescale_table( table* context, int scale_factor )
 	
 inline void model_b::recursive_flush( table* context, int scale_factor )
 {
-	// go through each link != nullptr
 	for (auto& link : context->links) {
 		if (link != nullptr) {
 			recursive_flush(link, scale_factor);
@@ -960,7 +958,6 @@ inline void model_b::recursive_flush( table* context, int scale_factor )
 	
 inline void model_b::recursive_cleanup( table *context )
 {
-	// go through each link != nullptr
 	for (auto& link : context->links) {
 		if (link != nullptr) {
 			recursive_cleanup(link);

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -267,17 +267,12 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	// c_lim (maximum count) -> 2 <= c_lim <= 4096 (???)
 	// WARNING: this can be memory intensive, so don't overdo it
 	// max_s == 256; max_c == 256; max_o == 4 would be way too much
-
-	table_s* null_table;
-	table_s* start_table;
-	int i;
 	
 	// copy settings into model
 	max_symbol  = max_s;
 	max_context = max_c;
 	max_order   = max_o;
 	max_count   = c_lim;
-	
 	
 	// alloc memory for totals table
 	totals = new unsigned int[max_symbol + 2];
@@ -291,9 +286,8 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	// set current order
 	current_order = max_order;
 	
-	
 	// set up null table
-	null_table = new table_s;
+	table_s* null_table = new table_s;
 	null_table->counts = new unsigned short[max_symbol];
 	std::fill(null_table->counts, null_table->counts + max_symbol, unsigned short(1)); // Set all probabilities.
 
@@ -302,7 +296,7 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	null_table->max_symbol = max_symbol;
 	
 	// set up start table
-	start_table = new table_s;
+	table_s* start_table = new table_s;
 	start_table->links = new table_s*[max_context];
 	std::fill(start_table->links, start_table->links + max_context, nullptr);
 	// set up internal counts
@@ -324,7 +318,7 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	contexts[  0 ] = start_table;
 	
 	// build initial 'normal' tables
-	for ( i = 1; i <= max_order; i++ ) {
+	for (int i = 1; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table_s;
 		contexts[ i ]->max_count  = 0;
@@ -743,26 +737,20 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	// ... (maximum symbol) -> 2 (0 or 1 )
 	// max_c (maximum context) -> 1 <= max_c <= 1024 (???)
 	// max_o (maximum order) -> -1 <= max_o <= 4
-
-	table* null_table;
-	table* start_table;
-	int i;
-	
 	
 	// copy settings into model
 	max_context = max_c;
 	max_order   = max_o;
 	max_count   = c_lim;
 	
-	
 	// set up null table
-	null_table = new table;
+	table* null_table = new table;
 	null_table->counts = new unsigned short[2];
 	std::fill_n(null_table->counts, 2, unsigned short(1));
 	null_table->scale = 2;
 	
 	// set up start table
-	start_table = new table;
+	table* start_table = new table;
 	start_table->links = new table*[max_context];
 	std::fill_n(start_table->links, max_context, nullptr);
 	start_table->scale = 0;
@@ -781,7 +769,7 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	contexts[  0 ] = start_table;
 	
 	// build initial 'normal' tables
-	for ( i = 1; i <= max_order; i++ ) {
+	for (int i = 1; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table;
 		contexts[ i ]->scale = 0;

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -711,7 +711,7 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	
 	// copy settings into model
 	max_context = max_c;
-	max_order   = max_o;
+	max_order   = max_o + 1;
 	max_count   = c_lim;
 	
 	// set up null table
@@ -730,15 +730,14 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	null_table->links = std::vector<table*>(max_context, start_table);
 	
 	// alloc memory for storage & contexts
-	storage = new table*[max_order + 3];
-	contexts = storage + 1;
+	contexts = std::vector<table*>(max_order + 2);
 	
 	// integrate tables into contexts
-	contexts[ -1 ] = null_table;
-	contexts[  0 ] = start_table;
+	contexts[ 0 ] = null_table;
+	contexts[ 1 ] = start_table;
 	
 	// build initial 'normal' tables
-	for (int i = 1; i <= max_order; i++ ) {
+	for (int i = 2; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table;
 		contexts[ i ]->scale = 0;
@@ -762,18 +761,15 @@ model_b::~model_b()
 	
 	
 	// clean up each 'normal' table
-	context = contexts[ 0 ];
+	context = contexts[ 1 ];
 	recursive_cleanup ( context );
 	
 	// clean up null table
-	context = contexts[ -1 ];
+	context = contexts[ 0];
 	if (context->counts != nullptr) {
 		delete[] context->counts;
 	}
 	delete context;
-	
-	// free everything else
-	delete[] storage;
 }
 
 
@@ -809,10 +805,10 @@ void model_b::shift_context( int c )
 {
 	// shifting is not possible if max_order is below 1
 	// or context index is negative
-	if ( (max_order < 1 ) || ( c < 0 ) ) return;
+	if ( (max_order < 2 ) || ( c < 0 ) ) return;
 	
 	// shift each orders' context
-	for (int i = max_order; i > 0; i-- ) {
+	for (int i = max_order; i > 1; i-- ) {
 		// this is the new current order context
 		table* context = contexts[ i - 1 ]->links[ c ];
 		
@@ -847,7 +843,7 @@ void model_b::shift_context( int c )
 	
 void model_b::flush_model( int scale_factor )
 {
-	recursive_flush( contexts[ 0 ], scale_factor );
+	recursive_flush( contexts[ 1 ], scale_factor );
 }
 
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -10,32 +10,11 @@
 	constructor for aricoder class
 	----------------------------------------------- */
 
-aricoder::aricoder( iostream* stream, int iomode )
-{	
-	// iomode (i/o mode)
-	// 0 -> reading
-	// 1 -> writing
-	
-	int i;
-	
-	// set initial values
-	ccode	= 0;
-	clow	= 0;
-	chigh	= CODER_LIMIT100 - 1;
-	cstep	= 0;
-	bbyte	= 0;
-	cbit	= 0;
-	nrbits	= 0;
-	
-	// store pointer to iostream for reading/writing
-	sptr = stream;
-	
-	// store i/o mode
-	mode = iomode;
-	
-	if ( mode == 0 ) { // mode is reading / decoding
+aricoder::aricoder( iostream* stream, StreamMode iomode ) : sptr(stream), mode(iomode)
+{
+	if ( mode == StreamMode::kRead) { // mode is reading / decoding
 		// code buffer has to be filled before starting decoding
-		for ( i = 0; i < CODER_USE_BITS; i++ )
+		for (int i = 0; i < CODER_USE_BITS; i++ )
 			ccode = ( ccode << 1 ) | read_bit();
 	} // mode is writing / encoding otherwise
 }
@@ -46,7 +25,7 @@ aricoder::aricoder( iostream* stream, int iomode )
 
 aricoder::~aricoder()
 {
-	if ( mode == 1 ) { // mode is writing / encoding
+	if ( mode == StreamMode::kWrite) { // mode is writing / encoding
 		// due to clow < CODER_LIMIT050, and chigh >= CODER_LIMIT050
 		// there are only two possible cases
 		if ( clow < CODER_LIMIT025 ) { // case a.) 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -386,18 +386,14 @@ model_s::~model_s()
 void model_s::update_model( int symbol )
 {
 	// use -1 if you just want to reset without updating statistics
-	
-	table_s* context;
-	unsigned short* counts;
-	int local_order;	
-	
+		
 	// only contexts, that were actually used to encode
 	// the symbol get their counts updated
 	if ( symbol >= 0 ) {
-		for ( local_order = ( current_order < 0 ) ? 0 : current_order;
+		for (int local_order = ( current_order < 0 ) ? 0 : current_order;
 				local_order <= max_order; local_order++ ) {
-			context = contexts[ local_order ];
-			counts = context->counts + symbol;
+			table_s* context = contexts[ local_order ];
+			unsigned short* counts = context->counts + symbol;
 			// update count for specific symbol & scale
 			(*counts)++;
 			// store side information for totalize_table
@@ -879,17 +875,14 @@ void model_b::update_model( int symbol )
 	
 void model_b::shift_context( int c )
 {
-	table* context;
-	int i;
-	
 	// shifting is not possible if max_order is below 1
 	// or context index is negative
-	if ( ( max_order < 1 ) || ( c < 0 ) ) return;
+	if ( (max_order < 1 ) || ( c < 0 ) ) return;
 	
 	// shift each orders' context
-	for ( i = max_order; i > 0; i-- ) {
+	for (int i = max_order; i > 0; i-- ) {
 		// this is the new current order context
-		context = contexts[ i - 1 ]->links[ c ];
+		table* context = contexts[ i - 1 ]->links[ c ];
 		
 		// check if context exists, build if needed
 		if ( context == nullptr ) {
@@ -901,7 +894,7 @@ void model_b::shift_context( int c )
 			// link lesser context later if not existing, this is done below
 			context->lesser = contexts[ i - 2 ]->links[ c ];
 			// finished here if this is a max order context
-			if ( i == max_order ) {
+			if ( i == max_order) {
 				context->links = nullptr;
 			}
 			else {
@@ -1044,11 +1037,9 @@ inline void model_b::rescale_table( table* context, int scale_factor )
 	
 inline void model_b::recursive_flush( table* context, int scale_factor )
 {
-	int i;
-
 	// go through each link != nullptr
 	if ( context->links != nullptr )
-		for ( i = 0; i < max_context; i++ )
+		for (int  i = 0; i < max_context; i++ )
 			if ( context->links[ i ] != nullptr )
 				recursive_flush( context->links[ i ], scale_factor );
     
@@ -1063,11 +1054,9 @@ inline void model_b::recursive_flush( table* context, int scale_factor )
 	
 inline void model_b::recursive_cleanup( table *context )
 {
-	int i;
-
 	// go through each link != nullptr
 	if ( context->links != nullptr ) {
-		for ( i = 0; i < max_context; i++ )
+		for (int i = 0; i < max_context; i++ )
 			if ( context->links[ i ] != nullptr )
 				recursive_cleanup( context->links[ i ] );
 		delete[] context->links;

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -694,7 +694,7 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	// set up null table
 	table* null_table = new table;
 	null_table->counts = std::vector<uint16_t>(2, uint16_t(1));
-	null_table->scale = 2;
+	null_table->scale = uint32_t(2);
 	
 	// set up start table
 	table* start_table = new table;
@@ -825,7 +825,7 @@ int model_b::convert_int_to_symbol( int c, symbol *s )
 	
 	// return high and low count for current symbol
 	if ( c == 0 ) { // if 0 is to be encoded
-		s->low_count  = 0;
+		s->low_count  = uint32_t(0);
 		s->high_count = context->counts[ 0 ];
 	}
 	else { // if 1 is to be encoded
@@ -864,7 +864,7 @@ int model_b::convert_symbol_to_int( int count, symbol *s )
 	
 	// set up the current symbol
 	if ( count < counts0 ) {
-		s->low_count  = 0;
+		s->low_count  = uint32_t(0);
 		s->high_count = counts0;
 		return 0;
 	}
@@ -889,7 +889,7 @@ inline void model_b::check_counts( table *context )
 		// setup counts for current table
 		counts.resize(2, uint16_t(1));
 		// set scale
-		context->scale = 2;
+		context->scale = uint32_t(2);
 	}
 }
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -772,14 +772,12 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	
 	// set up null table
 	null_table = new table;
-	null_table->lesser = nullptr;
 	null_table->counts = new unsigned short[2];
 	std::fill_n(null_table->counts, 2, unsigned short(1));
 	null_table->scale = 2;
 	
 	// set up start table
 	start_table = new table;
-	start_table->counts = nullptr;
 	start_table->links = new table*[max_context];
 	std::fill_n(start_table->links, max_context, nullptr);
 	start_table->scale = 0;
@@ -801,16 +799,12 @@ model_b::model_b( int max_c, int max_o, int c_lim )
 	for ( i = 1; i <= max_order; i++ ) {
 		// set up current order table
 		contexts[i] = new table;
-		contexts[i]->counts = nullptr;
 		contexts[ i ]->scale = 0;
 		// build forward and backward links
 		contexts[ i ]->lesser = contexts[ i - 1 ];
 		if ( i < max_order ) {
 			contexts[i]->links = new table*[max_context];
 			std::fill_n(contexts[i]->links, max_context, nullptr);
-		}
-		else {
-			contexts[ i ]->links = nullptr;
 		}
 		contexts[ i - 1 ]->links[ 0 ] = contexts[ i ];
 	}
@@ -889,15 +883,11 @@ void model_b::shift_context( int c )
 			// reserve memory for next table
 			context = new table;		
 			// set internal counts nullptr
-			context->counts = nullptr;
 			context->scale  = 0;	
 			// link lesser context later if not existing, this is done below
 			context->lesser = contexts[ i - 2 ]->links[ c ];
 			// finished here if this is a max order context
-			if ( i == max_order) {
-				context->links = nullptr;
-			}
-			else {
+			if ( i < max_order) {
 				// build links to higher order tables otherwise
 				context->links = new table*[max_context];
 				std::fill_n(context->links, max_context, nullptr);

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -275,8 +275,9 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim )
 	max_count   = c_lim;
 	
 	// alloc memory for totals table
-	totals = new unsigned int[max_symbol + 2];
-	std::fill(totals, totals + max_symbol + 2, unsigned int(0));
+	totals = std::vector<uint32_t>(max_symbol + 2);
+	/*totals = new unsigned int[max_symbol + 2];
+	std::fill(totals, totals + max_symbol + 2, unsigned int(0));*/
 	
 	// alloc memory for scoreboard, set sb0_count
 	scoreboard = new bool[max_symbol];
@@ -359,7 +360,6 @@ model_s::~model_s()
 	
 	// free everything else
 	delete[] storage;
-	delete[] totals;
 	delete[] scoreboard;
 }
 

--- a/source/aricoder.cpp
+++ b/source/aricoder.cpp
@@ -252,8 +252,8 @@ model_s::model_s( int max_s, int max_c, int max_o, int c_lim ) :
 		max_order(max_o + 1),
 		max_count(c_lim),
 
-		sb0_count(max_s),
-		current_order(max_o + 1)
+		current_order(max_o + 1),
+		sb0_count(max_s)
 {
 	// alloc memory for totals table
 	totals = std::vector<uint32_t>(max_symbol + 2);

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "bitops.h"
+#include <vector>
 
 // defines for coder
 constexpr uint32_t CODER_USE_BITS = 31; // Must never be above 31.
@@ -119,8 +120,7 @@ class model_s
 	
 	private:
 	
-	// unsigned short* totals;
-	unsigned int* totals;
+	std::vector<uint32_t> totals;
 	bool* scoreboard;
 	int sb0_count;
 	table_s **contexts;

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -34,7 +34,7 @@ struct table {
 	uint32_t scale = uint32_t(0);
 
 	/* -----------------------------------------------
-	Deletes all contexts starting at the table (including those it links to).
+	Recursively deletes all the tables pointed to in links.
 	----------------------------------------------- */
 	~table() {
 		for (auto& link : links) {
@@ -45,7 +45,7 @@ struct table {
 	}
 
 	/* -----------------------------------------------
-	Checks if counts exist, creating them if they do not.
+	Checks if counts exist, creating it if it does not.
 	----------------------------------------------- */
 	inline void check_counts() {
 		// check if counts are available
@@ -71,7 +71,7 @@ struct table {
 	}
 
 	/* -----------------------------------------------
-	Recursively rescales the counts in each link by the given factor.
+	Recursively runs rescale_table on this and all linked contexts.
 	----------------------------------------------- */
 	inline void recursive_flush() {
 		for (auto& link : links) {
@@ -96,7 +96,7 @@ struct table_s {
 	uint16_t max_symbol = uint16_t(0);
 
 	/* -----------------------------------------------
-	Deletes all contexts starting at the table_s (including those it links to).
+	Recursively deletes all the tables pointed to in links.
 	----------------------------------------------- */
 	~table_s() {
 		for (auto& link : links) {
@@ -133,7 +133,7 @@ struct table_s {
 	}
 
 	/* -----------------------------------------------
-	A recursive function that goes through each linked context and rescales the counts.
+	Recursively runs rescale_table on this and all linked contexts.
 	----------------------------------------------- */
 	inline void recursive_flush() {
 		for (auto& link : links) {

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -28,9 +28,9 @@ struct table {
 	// counts for each symbol contained in the table
 	unsigned short* counts = nullptr;
 	// links to higher order contexts
-	struct table** links = nullptr;
+	std::vector<table*> links;
 	// link to lower order context
-	struct table* lesser = nullptr;
+	table* lesser = nullptr;
 	// accumulated counts
 	unsigned int scale = unsigned int(0);
 };

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -112,7 +112,7 @@ class model_s
 	
 	int  convert_int_to_symbol( int c, symbol *s );
 	void get_symbol_scale( symbol *s );
-	int  convert_symbol_to_int( int count, symbol *s );
+	int  convert_symbol_to_int(uint32_t count, symbol *s);
 	
 	private:
 
@@ -152,7 +152,7 @@ class model_b
 	
 	int  convert_int_to_symbol( int c, symbol *s );
 	void get_symbol_scale( symbol *s );
-	int  convert_symbol_to_int( int count, symbol *s );	
+	int  convert_symbol_to_int(uint32_t count, symbol *s);	
 	
 	private:
 

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -41,9 +41,9 @@ struct table_s {
 	// counts for each symbol contained in the table
 	unsigned short* counts = nullptr;
 	// links to higher order contexts
-	struct table_s** links = nullptr;
+	std::vector<table_s*> links;
 	// link to lower order context
-	struct table_s* lesser = nullptr;
+	table_s* lesser = nullptr;
 	// speedup info
 	unsigned short max_count = unsigned short(0);
 	unsigned short max_symbol = unsigned short(0);

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -115,22 +115,23 @@ class model_s
 	int  convert_symbol_to_int( int count, symbol *s );
 	
 	private:
+
+	inline void totalize_table(table_s* context);
+	inline void rescale_table(table_s* context, int scale_factor);
+	inline void recursive_flush(table_s* context, int scale_factor);
+	inline void recursive_cleanup(table_s* context);
+
+	const int max_symbol;
+	const int max_context;
+	const int max_order;
+	const int max_count;
+
+	int current_order;
+	int sb0_count;
 	
 	std::vector<uint32_t> totals;
 	bool* scoreboard;
-	int sb0_count;
 	std::vector<table_s*> contexts;
-	
-	int max_symbol;
-	int max_context;
-	int current_order;
-	int max_order;
-	int max_count;
-	
-	inline void totalize_table(table_s* context );
-	inline void rescale_table(table_s* context, int scale_factor );
-	inline void recursive_flush(table_s* context, int scale_factor );
-	inline void recursive_cleanup(table_s* context );
 };
 
 
@@ -154,17 +155,17 @@ class model_b
 	int  convert_symbol_to_int( int count, symbol *s );	
 	
 	private:
+
+	inline void check_counts(table *context);
+	inline void rescale_table(table* context, int scale_factor);
+	inline void recursive_flush(table* context, int scale_factor);
+	inline void recursive_cleanup(table *context);
+
+	const int max_context;
+	const int max_order;
+	const int max_count;
 	
 	std::vector<table*> contexts;
-	
-	int max_context;
-	int max_order;
-	int max_count;
-	
-	inline void check_counts( table *context );
-	inline void rescale_table( table* context, int scale_factor );
-	inline void recursive_flush( table* context, int scale_factor );
-	inline void recursive_cleanup( table *context );
 };
 
 // Base case for shifting an arbitrary number of contexts into the model.

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -1,16 +1,18 @@
 #ifndef aricoder_h
 #define aricoder_h
 
-// defines for coder
-#define CODER_USE_BITS		31 // must never be above 31
-#define CODER_LIMIT100		( (unsigned int) ( 1 << CODER_USE_BITS ) )
-#define CODER_LIMIT025		( ( CODER_LIMIT100 / 4 ) * 1 )
-#define CODER_LIMIT050		( ( CODER_LIMIT100 / 4 ) * 2 )
-#define CODER_LIMIT075		( ( CODER_LIMIT100 / 4 ) * 3 )
-#define CODER_MAXSCALE		CODER_LIMIT025 - 1
-#define ESCAPE_SYMBOL		CODER_LIMIT025
+#include <cstdint>
 
 #include "bitops.h"
+
+// defines for coder
+constexpr uint32_t CODER_USE_BITS = 31; // Must never be above 31.
+constexpr uint32_t CODER_LIMIT100 = uint32_t(1 << CODER_USE_BITS);
+constexpr uint32_t CODER_LIMIT025 = CODER_LIMIT100 / 4;
+constexpr uint32_t CODER_LIMIT050 = (CODER_LIMIT100 / 4) * 2;
+constexpr uint32_t CODER_LIMIT075 = (CODER_LIMIT100 / 4) * 3;
+constexpr uint32_t CODER_MAXSCALE = CODER_LIMIT025 - 1;
+constexpr uint32_t ESCAPE_SYMBOL = CODER_LIMIT025;
 
 // symbol struct, used in arithmetic coding
 struct symbol {
@@ -29,7 +31,7 @@ struct table {
 	// link to lower order context
 	struct table* lesser = nullptr;
 	// accumulated counts
-	unsigned int scale = 0;
+	unsigned int scale = unsigned int(0);
 };
 
 // special table struct, used in in model_s,

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -159,8 +159,7 @@ class model_b
 	
 	private:
 	
-	table **contexts;
-	table **storage;
+	std::vector<table*> contexts;
 	
 	int max_context;
 	int max_order;

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -123,7 +123,7 @@ class model_s
 	std::vector<uint32_t> totals;
 	bool* scoreboard;
 	int sb0_count;
-	table_s **contexts;
+	std::vector<table_s*> contexts;
 	
 	int max_symbol;
 	int max_context;

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -1,5 +1,5 @@
-#ifndef aricoder_h
-#define aricoder_h
+#ifndef ARICODER_H
+#define ARICODER_H
 
 #include <cstdint>
 
@@ -17,9 +17,9 @@ constexpr uint32_t ESCAPE_SYMBOL = CODER_LIMIT025;
 
 // symbol struct, used in arithmetic coding
 struct symbol {
-    unsigned int low_count;
-	unsigned int high_count;
-	unsigned int scale;
+	uint32_t low_count;
+	uint32_t high_count;
+	uint32_t scale;
 };
 
 // table struct, used in in statistical models,
@@ -30,7 +30,7 @@ struct table {
 	// links to higher order contexts
 	std::vector<table*> links;
 	// accumulated counts
-	unsigned int scale = unsigned int(0);
+	uint32_t scale = uint32_t(0);
 };
 
 // special table struct, used in in model_s,
@@ -41,8 +41,8 @@ struct table_s {
 	// links to higher order contexts
 	std::vector<table_s*> links;
 	// speedup info
-	unsigned short max_count = unsigned short(0);
-	unsigned short max_symbol = unsigned short(0);
+	uint16_t max_count = uint16_t(0);
+	uint16_t max_symbol = uint16_t(0);
 };
 
 

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -210,7 +210,7 @@ class model_s
 	void update_model( int symbol );
 	void shift_context( int c );
 	void flush_model();
-	void exclude_symbols( char rule, int c );
+	void exclude_symbols(int c);
 	
 	int  convert_int_to_symbol( int c, symbol *s );
 	void get_symbol_scale( symbol *s );

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -110,23 +110,25 @@ struct table_s {
 	Resizes the table by rightshifting each count by scale_factor.
 	----------------------------------------------- */
 	inline void rescale_table(int scale_factor) {
-		// return now if counts not set
+		// Nothing to do if counts has not been set.
 		if (counts.empty()) return;
 
 		// now scale the table by bitshifting each count
 		int lst_symbol = max_symbol;
 		int i;
 		for (i = 0; i < lst_symbol; i++) {
-			//if ( counts[ i ] > 0 ) // Unnecessary check since counts is an unsigned type.
-			counts[i] >>= scale_factor;
+			counts[i] >>= scale_factor; // Counts will not become negative since it is an unsigned type.
 		}
 
 		// also rescale tables max count
 		max_count >>= scale_factor;
 
 		// seek for new last symbol
-		for (i = lst_symbol - 1; i >= 0; i--)
-			if (counts[i] > 0) break;
+		for (i = lst_symbol - 1; i >= 0; i--) {
+			if (counts[i] > 0) {
+				break;
+			}
+		}
 		max_symbol = i + 1;
 	}
 

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -26,7 +26,7 @@ struct symbol {
 // holding all info needed for one context
 struct table {
 	// counts for each symbol contained in the table
-	unsigned short* counts = nullptr;
+	std::vector<uint16_t> counts;
 	// links to higher order contexts
 	std::vector<table*> links;
 	// link to lower order context

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -1,3 +1,6 @@
+#ifndef aricoder_h
+#define aricoder_h
+
 // defines for coder
 #define CODER_USE_BITS		31 // must never be above 31
 #define CODER_LIMIT100		( (unsigned int) ( 1 << CODER_USE_BITS ) )
@@ -7,6 +10,7 @@
 #define CODER_MAXSCALE		CODER_LIMIT025 - 1
 #define ESCAPE_SYMBOL		CODER_LIMIT025
 
+#include "bitops.h"
 
 // symbol struct, used in arithmetic coding
 struct symbol {
@@ -40,7 +44,6 @@ struct table_s {
 	// speedup info
 	unsigned short max_count = unsigned short(0);
 	unsigned short max_symbol = unsigned short(0);
-	// unsigned short esc_prob;
 };
 
 
@@ -112,9 +115,6 @@ class model_s
 	void get_symbol_scale( symbol *s );
 	int  convert_symbol_to_int( int count, symbol *s );
 	
-	bool error;
-	
-	
 	private:
 	
 	// unsigned short* totals;
@@ -154,10 +154,7 @@ class model_b
 	
 	int  convert_int_to_symbol( int c, symbol *s );
 	void get_symbol_scale( symbol *s );
-	int  convert_symbol_to_int( int count, symbol *s );
-	
-	bool error;
-	
+	int  convert_symbol_to_int( int count, symbol *s );	
 	
 	private:
 	
@@ -249,3 +246,5 @@ static inline int decode_ari( aricoder* decoder, model_b* model )
 	
 	return c;
 }
+
+#endif

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -172,7 +172,7 @@ class aricoder
 
 		// write bit if done
 		if (cbit == 8) {
-			sptr->write(&bbyte, 1, 1);
+			sptr->write_byte(bbyte);
 			cbit = 0;
 		}
 	}

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -52,15 +52,28 @@ class aricoder
 {
 	public:
 	aricoder( iostream* stream, int iomode );
-	~aricoder( void );
+	~aricoder();
 	void encode( symbol* s );
 	unsigned int decode_count( symbol* s );
 	void decode( symbol* s );
 	
 	private:
-	// bitwise operations
-	void write_bit( unsigned char bit );
-	unsigned char read_bit( void );
+
+	template<uint8_t bit>
+	void write_bit() {
+		// add bit at last position
+		bbyte = (bbyte << 1) | bit;
+		// increment bit position
+		cbit++;
+
+		// write bit if done
+		if (cbit == 8) {
+			sptr->write(&bbyte, 1, 1);
+			cbit = 0;
+		}
+	}
+	
+	unsigned char read_bit();
 	
 	// i/o variables
 	iostream* sptr;
@@ -86,7 +99,7 @@ class model_s
 	public:
 	
 	model_s( int max_s, int max_c, int max_o, int c_lim );
-	~model_s( void );
+	~model_s();
 	
 	void update_model( int symbol );
 	void shift_context( int c );
@@ -104,7 +117,7 @@ class model_s
 	
 	// unsigned short* totals;
 	unsigned int* totals;
-	char* scoreboard;
+	bool* scoreboard;
 	int sb0_count;
 	table_s **contexts;
 	table_s **storage;
@@ -131,7 +144,7 @@ class model_b
 	public:
 	
 	model_b( int max_c, int max_o, int c_lim );
-	~model_b( void );
+	~model_b();
 	
 	void update_model( int symbol );
 	void shift_context( int c );

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -19,13 +19,13 @@ struct symbol {
 // holding all info needed for one context
 struct table {
 	// counts for each symbol contained in the table
-	unsigned short* counts;
+	unsigned short* counts = nullptr;
 	// links to higher order contexts
-	struct table** links;
+	struct table** links = nullptr;
 	// link to lower order context
-	struct table* lesser;	
+	struct table* lesser = nullptr;
 	// accumulated counts
-	unsigned int scale;
+	unsigned int scale = 0;
 };
 
 // special table struct, used in in model_s,

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -39,7 +39,7 @@ struct table {
 // holding additional info for a speedier 'totalize_table'
 struct table_s {
 	// counts for each symbol contained in the table
-	unsigned short* counts = nullptr;
+	std::vector<uint16_t> counts;
 	// links to higher order contexts
 	std::vector<table_s*> links;
 	// link to lower order context

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -187,8 +187,8 @@ static void shift_model(M model, C context, Cargs ... contextList) {
 	----------------------------------------------- */
 static inline void encode_ari( aricoder* encoder, model_s* model, int c )
 {
-	static symbol s;
-	static int esc;
+	symbol s;
+	int esc;
 	
 	do {		
 		esc = model->convert_int_to_symbol( c, &s );
@@ -202,9 +202,9 @@ static inline void encode_ari( aricoder* encoder, model_s* model, int c )
 	----------------------------------------------- */	
 static inline int decode_ari( aricoder* decoder, model_s* model )
 {
-	static symbol s;
-	static unsigned int count;
-	static int c;
+	symbol s;
+	uint32_t count;
+	int c;
 	
 	do{
 		model->get_symbol_scale( &s );
@@ -222,7 +222,7 @@ static inline int decode_ari( aricoder* decoder, model_s* model )
 	----------------------------------------------- */	
 static inline void encode_ari( aricoder* encoder, model_b* model, int c )
 {
-	static symbol s;
+	symbol s;
 	
 	model->convert_int_to_symbol( c, &s );
 	encoder->encode( &s );
@@ -234,13 +234,11 @@ static inline void encode_ari( aricoder* encoder, model_b* model, int c )
 	----------------------------------------------- */	
 static inline int decode_ari( aricoder* decoder, model_b* model )
 {
-	static symbol s;
-	static unsigned int count;
-	static int c;
+	symbol s;
 	
 	model->get_symbol_scale( &s );
-	count = decoder->decode_count( &s );
-	c = model->convert_symbol_to_int( count, &s );
+	uint32_t count = decoder->decode_count( &s );
+	int c = model->convert_symbol_to_int( count, &s );
 	decoder->decode( &s );	
 	model->update_model( c );
 	

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -174,48 +174,16 @@ class model_b
 	inline void recursive_cleanup( table *context );
 };
 
+// Base case for shifting an arbitrary number of contexts into the model.
+template <typename M>
+static void shift_model(M model) {}
 
-/* -----------------------------------------------
-	shift context x2 model_s function
-	----------------------------------------------- */
-static inline void shift_model( model_s* model, int ctx1, int ctx2 )
-{
-	model->shift_context( ctx1 );
-	model->shift_context( ctx2 );
+// Shift an arbitrary number of contexts into the model (at most max_c contexts).
+template <typename M, typename C, typename... Cargs>
+static void shift_model(M model, C context, Cargs ... contextList) {
+	model->shift_context(context);
+	shift_model(model, contextList...);
 }
-
-
-/* -----------------------------------------------
-	shift context x3 model_s function
-	----------------------------------------------- */
-static inline void shift_model( model_s* model, int ctx1, int ctx2, int ctx3 )
-{
-	model->shift_context( ctx1 );
-	model->shift_context( ctx2 );
-	model->shift_context( ctx3 );
-}
-
-
-/* -----------------------------------------------
-	shift context x2 model_b function
-	----------------------------------------------- */
-static inline void shift_model( model_b* model, int ctx1, int ctx2 )
-{
-	model->shift_context( ctx1 );
-	model->shift_context( ctx2 );
-}
-
-
-/* -----------------------------------------------
-	shift context x3 model_b function
-	----------------------------------------------- */
-static inline void shift_model( model_b* model, int ctx1, int ctx2, int ctx3 )
-{
-	model->shift_context( ctx1 );
-	model->shift_context( ctx2 );
-	model->shift_context( ctx3 );
-}
-
 
 /* -----------------------------------------------
 	generic model_s encoder function

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -73,6 +73,8 @@ class aricoder
 		}
 	}
 	
+	void writeNrbitsAsZero();
+	void writeNrbitsAsOne();
 	unsigned char read_bit();
 	
 	// i/o variables

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -29,8 +29,6 @@ struct table {
 	std::vector<uint16_t> counts;
 	// links to higher order contexts
 	std::vector<table*> links;
-	// link to lower order context
-	table* lesser = nullptr;
 	// accumulated counts
 	unsigned int scale = unsigned int(0);
 };
@@ -42,8 +40,6 @@ struct table_s {
 	std::vector<uint16_t> counts;
 	// links to higher order contexts
 	std::vector<table_s*> links;
-	// link to lower order context
-	table_s* lesser = nullptr;
 	// speedup info
 	unsigned short max_count = unsigned short(0);
 	unsigned short max_symbol = unsigned short(0);

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -53,7 +53,7 @@ struct table_s {
 class aricoder
 {
 	public:
-	aricoder( iostream* stream, int iomode );
+	aricoder( iostream* stream, StreamMode iomode );
 	~aricoder();
 	void encode( symbol* s );
 	unsigned int decode_count( symbol* s );
@@ -80,17 +80,17 @@ class aricoder
 	unsigned char read_bit();
 	
 	// i/o variables
-	iostream* sptr;
-	int mode;
-	unsigned char bbyte;
-	unsigned char cbit;
+	iostream* sptr; // Pointer to iostream for reading/writing.
+	const StreamMode mode;
+	unsigned char bbyte = 0;
+	unsigned char cbit = 0;
 	
 	// arithmetic coding variables
-	unsigned int ccode;
-	unsigned int clow;
-	unsigned int chigh;
-	unsigned int cstep;
-	unsigned int nrbits;
+	unsigned int ccode = 0;
+	unsigned int clow = 0;
+	unsigned int chigh = CODER_LIMIT100 - 1;
+	unsigned int cstep = 0;
+	unsigned int nrbits = 0;
 };
 
 

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -170,7 +170,7 @@ class model_b
 
 // Base case for shifting an arbitrary number of contexts into the model.
 template <typename M>
-static void shift_model(M model) {}
+static void shift_model(M) {}
 
 // Shift an arbitrary number of contexts into the model (at most max_c contexts).
 template <typename M, typename C, typename... Cargs>

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -124,7 +124,6 @@ class model_s
 	bool* scoreboard;
 	int sb0_count;
 	table_s **contexts;
-	table_s **storage;
 	
 	int max_symbol;
 	int max_context;

--- a/source/aricoder.h
+++ b/source/aricoder.h
@@ -32,14 +32,14 @@ struct table {
 // holding additional info for a speedier 'totalize_table'
 struct table_s {
 	// counts for each symbol contained in the table
-	unsigned short* counts;
+	unsigned short* counts = nullptr;
 	// links to higher order contexts
-	struct table_s** links;
+	struct table_s** links = nullptr;
 	// link to lower order context
-	struct table_s* lesser;
+	struct table_s* lesser = nullptr;
 	// speedup info
-	unsigned short max_count;
-	unsigned short max_symbol;
+	unsigned short max_count = unsigned short(0);
+	unsigned short max_symbol = unsigned short(0);
 	// unsigned short esc_prob;
 };
 

--- a/source/bitops.cpp
+++ b/source/bitops.cpp
@@ -9,6 +9,7 @@ reading and writing of arrays
 #include <array>
 #include <stdio.h>
 #include <stdlib.h>
+#include <vector>
 
 #if defined(_WIN32) || defined(WIN32)
 #include <fcntl.h>
@@ -498,7 +499,7 @@ void abytewriter::write( unsigned char byte )
 	writes n byte to abytewriter
 	----------------------------------------------- */
 	
-void abytewriter::write_n( unsigned char* byte, int n )
+void abytewriter::write_n(const unsigned char* byte, int n )
 {
 	// safety check for error
 	if ( error() || n < 0 ) return;
@@ -694,18 +695,26 @@ void iostream::switch_mode()
 	generic read function
 	----------------------------------------------- */
 	
-int iostream::read( void* to, int tpsize, int dtsize )
+int iostream::read(unsigned char* to, int dtsize)
 {
-	return ( srct == StreamType::kFile) ? read_file( to, tpsize, dtsize ) : read_mem( to, tpsize, dtsize );
+	return ( srct == StreamType::kFile) ? read_file( to, dtsize ) : read_mem( to, dtsize );
+}
+
+bool iostream::read_byte(unsigned char* to) {
+	return  srct == StreamType::kFile ? read_file_byte(to) : read_mem_byte(to);
 }
 
 /* -----------------------------------------------
 	generic write function
 	----------------------------------------------- */
 
-int iostream::write( void* from, int tpsize, int dtsize )
+int iostream::write(const unsigned char* from, int dtsize )
 {
-	return ( srct == StreamType::kFile) ? write_file( from, tpsize, dtsize ) : write_mem( from, tpsize, dtsize );
+	return ( srct == StreamType::kFile) ? write_file( from, dtsize ) : write_mem( from, dtsize );
+}
+
+int iostream::write_byte(unsigned char byte) {
+	return srct == StreamType::kFile ? write_file_byte(byte) : write_mem_byte(byte);
 }
 
 /* -----------------------------------------------
@@ -844,6 +853,10 @@ void iostream::open_file()
 	
 	// open file for reading / writing
 	fptr = fopen( fn, ( mode == StreamMode::kRead ) ? "rb" : "wb" );
+	if (fptr != nullptr) {
+		file_buffer.reserve(32768);
+		std::setvbuf(fptr, file_buffer.data(), _IOFBF, file_buffer.capacity());
+	}
 }
 
 /* -----------------------------------------------
@@ -869,7 +882,7 @@ void iostream::open_stream()
 		// read whole stream into memory buffer
 		auto strwrt = std::make_unique<abytewriter>( 0 );
 		constexpr int buffer_capacity = 1024 * 1024;
-		std::array<unsigned char, buffer_capacity> buffer;
+    std::vector<unsigned char> buffer(buffer_capacity);
 
 		int bytesRead = fread(buffer.data(), sizeof(buffer[0]), buffer_capacity, stdin);
 		while (bytesRead > 0) {
@@ -897,40 +910,55 @@ void iostream::open_stream()
 	write function for files
 	----------------------------------------------- */
 
-int iostream::write_file( void* from, int tpsize, int dtsize )
+int iostream::write_file(const unsigned char* from, int dtsize )
 {
-	return fwrite( from, tpsize, dtsize, fptr );
+	return fwrite( from, sizeof(unsigned char), dtsize, fptr );
+}
+
+int iostream::write_file_byte(unsigned char byte) {
+	return fputc(byte, fptr) == byte;
 }
 
 /* -----------------------------------------------
 	read function for files
 	----------------------------------------------- */
 
-int iostream::read_file( void* to, int tpsize, int dtsize )
+int iostream::read_file(unsigned char* to, int dtsize )
 {
-	return fread( to, tpsize, dtsize, fptr );
+	return fread( to, sizeof(unsigned char), dtsize, fptr );
+}
+
+bool iostream::read_file_byte(unsigned char* to) {
+	int val = fgetc(fptr);
+	*to = val;
+	return val != EOF;
 }
 
 /* -----------------------------------------------
 	write function for memory
 	----------------------------------------------- */
 	
-int iostream::write_mem( void* from, int tpsize, int dtsize )
-{
-	int n = tpsize * dtsize;
+int iostream::write_mem(const unsigned char* from, int dtsize )
+{	
+	mwrt->write_n(from, dtsize);
 	
-	mwrt->write_n( ( unsigned char* ) from, n );
-	
-	return ( mwrt->error()) ? 0 : n;
+	return ( mwrt->error()) ? 0 : dtsize;
+}
+
+int iostream::write_mem_byte(unsigned char byte) {
+	mwrt->write(byte);
+	return mwrt->error() ? 0 : 1;
 }
 
 /* -----------------------------------------------
 	read function for memory
 	----------------------------------------------- */
 
-int iostream::read_mem( void* to, int tpsize, int dtsize )
-{
-	int n = tpsize * dtsize;
-	
-	return ( mrdr->read_n( ( unsigned char* ) to, n ) ) / tpsize;
+int iostream::read_mem(unsigned char* to, int dtsize)
+{	
+	return mrdr->read_n(to, dtsize);
+}
+
+bool iostream::read_mem_byte(unsigned char* to) {
+	return mrdr->read(to) == 1;
 }

--- a/source/bitops.h
+++ b/source/bitops.h
@@ -1,5 +1,5 @@
-#ifndef bitops_h
-#define bitops_h
+#ifndef BITOPS_H
+#define BITOPS_H
 
 #define RBITS( c, n )		( c & ( 0xFF >> (8 - n) ) )
 #define LBITS( c, n )		( c >> (8 - n) )
@@ -11,6 +11,7 @@
 #define FDIV2( v, p )		( ( v < 0 ) ? -( (-v) >> p ) : ( v >> p ) )
 
 #include <memory>
+#include <vector>
 
 enum StreamType {
 	kFile = 0,
@@ -116,7 +117,7 @@ public:
 	abytewriter( int size );
 	~abytewriter();	
 	void write( unsigned char byte );
-	void write_n( unsigned char* byte, int n );
+	void write_n(const unsigned char* byte, int n );
 	unsigned char* getptr();
 	unsigned char* peekptr();
 	int getpos();
@@ -142,8 +143,10 @@ public:
 	iostream( void* src, StreamType srctype, int srcsize, StreamMode iomode );
 	~iostream();
 	void switch_mode();
-	int read( void* to, int tpsize, int dtsize );
-	int write( void* from, int tpsize, int dtsize );
+	int read(unsigned char* to, int dtsize);
+	bool read_byte(unsigned char* to);
+	int write(const unsigned char* from, int dtsize);
+	int write_byte(unsigned char byte);
 	int flush();
 	int rewind();
 	int getpos();
@@ -157,12 +160,18 @@ private:
 	void open_mem();
 	void open_stream();
 	
-	int write_file( void* from, int tpsize, int dtsize );
-	int read_file( void* to, int tpsize, int dtsize );
-	int write_mem( void* from, int tpsize, int dtsize );
-	int read_mem( void* to, int tpsize, int dtsize );
+	int write_file(const unsigned char* from, int dtsize);
+	int write_file_byte(unsigned char byte);
+	int read_file(unsigned char* to, int dtsize);
+	bool read_file_byte(unsigned char* to);
+	int write_mem(const unsigned char* from, int dtsize );
+	int write_mem_byte(unsigned char byte);
+	int read_mem(unsigned char* to, int dtsize);
+	bool read_mem_byte(unsigned char* to);
 	
 	FILE* fptr;
+	std::vector<char> file_buffer; // Used to replace the default file buffer for reads/writes to improve performance.
+  
 	std::unique_ptr<abytewriter> mwrt;
 	std::unique_ptr<abytereader> mrdr;
 	

--- a/source/bitops.h
+++ b/source/bitops.h
@@ -1,3 +1,6 @@
+#ifndef bitops_h
+#define bitops_h
+
 #define RBITS( c, n )		( c & ( 0xFF >> (8 - n) ) )
 #define LBITS( c, n )		( c >> (8 - n) )
 #define MBITS( c, l, r )	( RBITS( c,l ) >> r )
@@ -169,3 +172,5 @@ private:
 	StreamType srct;
 	int srcs;
 };
+
+#endif

--- a/source/packjpg.cpp
+++ b/source/packjpg.cpp
@@ -3279,7 +3279,7 @@ INTERN bool pack_pjg( void )
 	
 	
 	// init arithmetic compression
-	encoder = new aricoder( str_out, 1 );
+	encoder = new aricoder(str_out, StreamMode::kWrite);
 	
 	// discard meta information from header if option set
 	if ( disc_meta )
@@ -3416,7 +3416,7 @@ INTERN bool unpack_pjg( void )
 	
 	
 	// init arithmetic compression
-	decoder = new aricoder( str_in, 0 );
+	decoder = new aricoder(str_in, StreamMode::kRead);
 	
 	// decode JPG header
 	if ( !pjg_decode_generic( decoder, &hdrdata, &hdrs ) ) return false;

--- a/source/packjpg.cpp
+++ b/source/packjpg.cpp
@@ -5096,9 +5096,9 @@ INTERN bool pjg_encode_ac_high( aricoder* enc, int cmp )
 			}
 		}
 		// flush models
-		mod_len->flush_model( 1 );
-		mod_res->flush_model( 1 );
-		mod_sgn->flush_model( 1 );
+		mod_len->flush_model();
+		mod_res->flush_model();
+		mod_sgn->flush_model();
 	}
 	
 	// free memory / clear models
@@ -5261,10 +5261,10 @@ INTERN bool pjg_encode_ac_low( aricoder* enc, int cmp )
 			}
 		}
 		// flush models
-		mod_len->flush_model( 1 );
-		mod_res->flush_model( 1 );
-		mod_top->flush_model( 1 );
-		mod_sgn->flush_model( 1 );
+		mod_len->flush_model();
+		mod_res->flush_model();
+		mod_top->flush_model();
+		mod_sgn->flush_model();
 	}
 	
 	// free memory / clear models
@@ -5760,9 +5760,9 @@ INTERN bool pjg_decode_ac_high( aricoder* dec, int cmp )
 			}
 		}
 		// flush models
-		mod_len->flush_model( 1 );
-		mod_res->flush_model( 1 );
-		mod_sgn->flush_model( 1 );
+		mod_len->flush_model();
+		mod_res->flush_model();
+		mod_sgn->flush_model();
 	}
 	
 	// free memory / clear models
@@ -5923,10 +5923,10 @@ INTERN bool pjg_decode_ac_low( aricoder* dec, int cmp )
 			}
 		}
 		// flush models
-		mod_len->flush_model( 1 );
-		mod_res->flush_model( 1 );
-		mod_top->flush_model( 1 );
-		mod_sgn->flush_model( 1 );
+		mod_len->flush_model();
+		mod_res->flush_model();
+		mod_top->flush_model();
+		mod_sgn->flush_model();
 	}
 	
 	// free memory / clear models

--- a/source/packjpg.cpp
+++ b/source/packjpg.cpp
@@ -1779,7 +1779,7 @@ INTERN bool check_file( void )
 	if ( pjgfilename != NULL ) free( pjgfilename ); pjgfilename = NULL;
 	
 	// immediately return error if 2 bytes can't be read
-	if ( str_in->read( fileid, 1, 2 ) != 2 ) { 
+	if ( str_in->read( fileid, 2 ) != 2 ) { 
 		filetype = F_UNK;
 		sprintf( errormessage, "file doesn't contain enough data" );
 		errorlevel = 2;
@@ -1870,7 +1870,7 @@ INTERN bool check_file( void )
 #if !defined(BUILD_LIB)
 INTERN bool swap_streams( void )	
 {
-	char dmp[ 2 ];
+	unsigned char dmp[ 2 ];
 	
 	// store input stream
 	str_str = str_in;
@@ -1879,7 +1879,7 @@ INTERN bool swap_streams( void )
 	// replace input stream by output stream / switch mode for reading / read first bytes
 	str_in = str_out;
 	str_in->switch_mode();
-	str_in->read( dmp, 1, 2 );
+	str_in->read( dmp, 2 );
 	
 	// open new stream for output / check for errors
 	str_out = new iostream( nullptr, StreamType::kMemory, 0, StreamMode::kWrite );
@@ -1946,8 +1946,8 @@ INTERN bool compare_output( void )
 	for ( i = 0; i < dsize; i++ ) {
 		b = i % bsize;
 		if ( b == 0 ) {
-			str_str->read( buff_ori, sizeof( char ), bsize );
-			str_out->read( buff_cmp, sizeof( char ), bsize );
+			str_str->read( buff_ori, bsize );
+			str_out->read( buff_cmp, bsize );
 		}
 		if ( buff_ori[ b ] != buff_cmp[ b ] ) {
 			sprintf( errormessage, "difference found at 0x%X", i );
@@ -2111,7 +2111,7 @@ INTERN bool read_jpeg( void )
 			crst = 0;
 			while ( true ) {
 				// read byte from imagedata
-				if ( str_in->read( &tmp, 1, 1 ) == 0 )
+				if ( str_in->read_byte(&tmp) == 0 )
 					break;
 					
 				// non-0xFF loop
@@ -2119,14 +2119,14 @@ INTERN bool read_jpeg( void )
 					crst = 0;
 					while ( tmp != 0xFF ) {
 						huffw->write( tmp );
-						if ( str_in->read( &tmp, 1, 1 ) == 0 )
+						if ( str_in->read_byte(&tmp) == 0 )
 							break;
 					}
 				}
 				
 				// treatment of 0xFF
 				if ( tmp == 0xFF ) {
-					if ( str_in->read( &tmp, 1, 1 ) == 0 )
+					if ( str_in->read_byte(&tmp) == 0 )
 						break; // read next byte & check
 					if ( tmp == 0x00 ) {
 						crst = 0;
@@ -2181,13 +2181,13 @@ INTERN bool read_jpeg( void )
 		}
 		else {
 			// read in next marker
-			if ( str_in->read( segment, 1, 2 ) != 2 ) break;
+			if ( str_in->read( segment, 2 ) != 2 ) break;
 			if ( segment[ 0 ] != 0xFF ) {
 				// ugly fix for incorrect marker segment sizes
 				sprintf( errormessage, "size mismatch in marker segment FF %2X", type );
 				errorlevel = 2;
 				if ( type == 0xFE ) { //  if last marker was COM try again
-					if ( str_in->read( segment, 1, 2 ) != 2 ) break;
+					if ( str_in->read( segment, 2 ) != 2 ) break;
 					if ( segment[ 0 ] == 0xFF ) errorlevel = 1;
 				}
 				if ( errorlevel == 2 ) {
@@ -2215,7 +2215,7 @@ INTERN bool read_jpeg( void )
 		}
 		
 		// read in next segments' length and check it
-		if ( str_in->read( segment + 2, 1, 2 ) != 2 ) break;
+		if ( str_in->read( segment + 2, 2 ) != 2 ) break;
 		len = 2 + B_SHORT( segment[ 2 ], segment[ 3 ] );
 		if ( len < 4 ) break;
 		
@@ -2233,7 +2233,7 @@ INTERN bool read_jpeg( void )
 		}
 		
 		// read rest of segment, store back in header writer
-		if ( str_in->read( ( segment + 4 ), 1, ( len - 4 ) ) !=
+		if ( str_in->read( ( segment + 4 ), ( len - 4 ) ) !=
 			( unsigned short ) ( len - 4 ) ) break;
 		hdrw->write_n( segment, len );
 	}
@@ -2251,12 +2251,12 @@ INTERN bool read_jpeg( void )
 	}
 	
 	// store garbage after EOI if needed
-	grbs = str_in->read( &tmp, 1, 1 );	
+	grbs = str_in->read_byte(&tmp);
 	if ( grbs > 0 ) {
 		grbgw = new abytewriter( 1024 );
 		grbgw->write( tmp );
 		while( true ) {
-			len = str_in->read( segment, 1, ssize );
+			len = str_in->read( segment, ssize );
 			if ( len == 0 ) break;
 			grbgw->write_n( segment, len );
 		}
@@ -2304,7 +2304,7 @@ INTERN bool merge_jpeg( void )
 	
 	
 	// write SOI
-	str_out->write( SOI, 1, 2 );
+	str_out->write( SOI, 2 );
 	
 	// JPEG writing loop
 	while ( true )
@@ -2321,7 +2321,7 @@ INTERN bool merge_jpeg( void )
 		}
 		
 		// write header data to file
-		str_out->write( hdrdata + tmp, 1, ( hpos - tmp ) );
+		str_out->write( hdrdata + tmp, ( hpos - tmp ) );
 		
 		// get out if last marker segment type was not SOS
 		if ( type != 0xDA ) break;
@@ -2333,16 +2333,16 @@ INTERN bool merge_jpeg( void )
 		// write & expand huffman coded image data
 		for ( ipos = scnp[ scan - 1 ]; ipos < scnp[ scan ]; ipos++ ) {
 			// write current byte
-			str_out->write( huffdata + ipos, 1, 1 );
+			str_out->write_byte(huffdata[ipos]);
 			// check current byte, stuff if needed
 			if ( huffdata[ ipos ] == 0xFF )
-				str_out->write( &stv, 1, 1 );
+				str_out->write_byte(stv);
 			// insert restart markers if needed
 			if ( rstp != NULL ) {
 				if ( ipos == rstp[ rpos ] ) {
 					rst = 0xD0 + ( cpos % 8 );
-					str_out->write( &mrk, 1, 1 );
-					str_out->write( &rst, 1, 1 );
+					str_out->write_byte(mrk);
+					str_out->write_byte(rst);
 					rpos++; cpos++;
 				}
 			}
@@ -2351,8 +2351,8 @@ INTERN bool merge_jpeg( void )
 		if ( rst_err != NULL ) {
 			while ( rst_err[ scan - 1 ] > 0 ) {
 				rst = 0xD0 + ( cpos % 8 );
-				str_out->write( &mrk, 1, 1 );
-				str_out->write( &rst, 1, 1 );
+				str_out->write_byte(mrk);
+				str_out->write_byte(rst);
 				cpos++;	rst_err[ scan - 1 ]--;
 			}
 		}
@@ -2362,11 +2362,11 @@ INTERN bool merge_jpeg( void )
 	}
 	
 	// write EOI
-	str_out->write( EOI, 1, 2 );
+	str_out->write( EOI, 2 );
 	
 	// write garbage if needed
 	if ( grbs > 0 )
-		str_out->write( grbgdata, 1, grbs );
+		str_out->write( grbgdata, grbs );
 	
 	// errormessage if write error
 	if ( str_out->chkerr() ) {
@@ -3263,19 +3263,19 @@ INTERN bool pack_pjg( void )
 	
 	
 	// PJG-Header
-	str_out->write( (void*) pjg_magic, 1, 2 );
+	str_out->write( reinterpret_cast<const unsigned char*>(pjg_magic), 2 );
 	
 	// store settings if not auto
 	if ( !auto_set ) {
 		hcode = 0x00;
-		str_out->write( &hcode, 1, 1 );
-		str_out->write( nois_trs, 1, 4 );
-		str_out->write( segm_cnt, 1, 4 );
+		str_out->write_byte(hcode);
+		str_out->write( nois_trs, 4 );
+		str_out->write( segm_cnt, 4 );
 	}
 	
 	// store version number
 	hcode = appversion;
-	str_out->write( &hcode, 1, 1 );
+	str_out->write_byte(hcode);
 	
 	
 	// init arithmetic compression
@@ -3390,11 +3390,11 @@ INTERN bool unpack_pjg( void )
 	
 	// check header codes ( maybe position in other function ? )
 	while( true ) {
-		str_in->read( &hcode, 1, 1 );
+		str_in->read_byte(&hcode);
 		if ( hcode == 0x00 ) {
 			// retrieve compression settings from file
-			str_in->read( nois_trs, 1, 4 );
-			str_in->read( segm_cnt, 1, 4 );
+			str_in->read( nois_trs, 4 );
+			str_in->read( segm_cnt, 4 );
 			auto_set = false;
 		}
 		else if ( hcode >= 0x14 ) {

--- a/source/packjpg.cpp
+++ b/source/packjpg.cpp
@@ -4682,7 +4682,7 @@ INTERN bool pjg_encode_zstscan( aricoder* enc, int cmp )
 	for ( i = 1; i < 64; i++ )
 	{			
 		// reduce range of model
-		model->exclude_symbols( 'a', 64 - i );
+		model->exclude_symbols(64 - i);
 		
 		// compare remaining list to remainnig scan
 		tpos = 0;
@@ -5059,7 +5059,7 @@ INTERN bool pjg_encode_ac_high( aricoder* enc, int cmp )
 			ctx_len = BITLEN1024P( ctx_avr ); // BITLENGTH context				
 			// shift context / do context modelling (segmentation is done per context)
 			shift_model( mod_len, ctx_len, snum );
-			mod_len->exclude_symbols( 'a', max_len );		
+			mod_len->exclude_symbols(max_len);		
 		
 			// simple treatment if coefficient is zero
 			if ( coeffs[ dpos ] == 0 ) {
@@ -5219,7 +5219,7 @@ INTERN bool pjg_encode_ac_low( aricoder* enc, int cmp )
 			
 			// shift context / do context modelling (segmentation is done per context)
 			shift_model( mod_len, ctx_len, zdstls[ dpos ] );
-			mod_len->exclude_symbols( 'a', max_len );			
+			mod_len->exclude_symbols(max_len);			
 			
 			// simple treatment if coefficient is zero
 			if ( coeffs[ dpos ] == 0 ) {
@@ -5348,7 +5348,7 @@ INTERN bool pjg_decode_zstscan( aricoder* dec, int cmp )
 	for ( i = 1; i < 64; i++ )
 	{			
 		// reduce range of model
-		model->exclude_symbols( 'a', 64 - i );
+		model->exclude_symbols(64 - i);
 		
 		// decode symbol
 		cpos = decode_ari( dec, model );
@@ -5723,7 +5723,7 @@ INTERN bool pjg_decode_ac_high( aricoder* dec, int cmp )
 			ctx_len = BITLEN1024P( ctx_avr ); // BITLENGTH context				
 			// shift context / do context modelling (segmentation is done per context)
 			shift_model( mod_len, ctx_len, snum );
-			mod_len->exclude_symbols( 'a', max_len );
+			mod_len->exclude_symbols(max_len);
 			
 			// decode bit length of current coefficient
 			clen = decode_ari( dec, mod_len );			
@@ -5882,7 +5882,7 @@ INTERN bool pjg_decode_ac_low( aricoder* dec, int cmp )
 			ctx_len = BITLEN2048N( ctx_lak ); // BITLENGTH context				
 			// shift context / do context modelling (segmentation is done per context)
 			shift_model( mod_len, ctx_len, zdstls[ dpos ] );
-			mod_len->exclude_symbols( 'a', max_len );
+			mod_len->exclude_symbols(max_len);
 			
 			// decode bit length of current coefficient
 			clen = decode_ari( dec, mod_len );


### PR DESCRIPTION
5--10% runtime reduction due to optimizations in the aricoder.h/aricoder.cpp files:

1. Using memset where possible (through std::fill).
2. Cache localization for encode/decode.
3. Better memory allocation.

Improved safety at approximately no performance cost through:
1. Use of vectors instead of C-style arrays.
2. Constant-ization of fields where applicable.
3. Removed unused fields (e.g., table.lesser).
4. Code simplifications/abstractions.

5--10% runtime reduction due to optimizations in the bitops.h/bitops.cpp files:

1. Use of setvbuf for a larger file io buffer.
2. Implementation of write_byte and read_byte to replace write(void*)/read(void*) wherever possible.